### PR TITLE
Fixes an AttributeError that occurred on startup.

### DIFF
--- a/src/news_tui/widgets.py
+++ b/src/news_tui/widgets.py
@@ -32,12 +32,13 @@ class StatusBar(Static):
         if self.loading_status:
             status_items.append(self.loading_status)
 
-        bindings = self.app.screen.bindings
-        shown_bindings = [b for b in bindings.values() if b.show]
-        bindings_text = " | ".join(
-            f"[b cyan]{b.key}[/] {b.description}" for b in shown_bindings
-        )
-        status_items.append(bindings_text)
+        if hasattr(self.app, "screen") and hasattr(self.app.screen, "bindings"):
+            bindings = self.app.screen.bindings
+            shown_bindings = [b for b in bindings.values() if b.show]
+            bindings_text = " | ".join(
+                f"[b cyan]{b.key}[/] {b.description}" for b in shown_bindings
+            )
+            status_items.append(bindings_text)
 
         self.update(" | ".join(status_items))
 


### PR DESCRIPTION
The `StatusBar` widget was trying to access `self.app.screen.bindings` before the screen and its bindings were fully initialized. This was causing a crash.

This commit adds a check to ensure that `self.app.screen` and `self.app.screen.bindings` exist before trying to access them. This prevents the crash and ensures that the keybindings are displayed correctly once they are available.