### PR TITLE
Fixes an AttributeError when displaying keybindings in the status bar.

### DIFF
--- a/src/news_tui/widgets.py
+++ b/src/news_tui/widgets.py
@@ -34,7 +34,7 @@ class StatusBar(Static):
 
         if hasattr(self.app, "screen") and hasattr(self.app.screen, "bindings"):
             bindings = self.app.screen.bindings
-            shown_bindings = [b for b in bindings.values() if b.show]
+            shown_bindings = [b for b in bindings if b.show]
             bindings_text = " | ".join(
                 f"[b cyan]{b.key}[/] {b.description}" for b in shown_bindings
             )


### PR DESCRIPTION
The `bindings` attribute of a screen is a list, not a dictionary. The code was trying to call `.values()` on this list, which caused a crash.

This commit corrects the code to iterate over the `bindings` list directly, resolving the `AttributeError`.