### PR TITLE
feat: Add settings window and improve UI

### DIFF
--- a/src/news_tui/config.py
+++ b/src/news_tui/config.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 # --- Configuration ---
 HOME_PAGE_URL = "https://www.cbc.ca/lite"
@@ -107,6 +107,17 @@ def load_config() -> Dict[str, Any]:
     except (IOError, json.JSONDecodeError) as e:
         logger.error("Failed to load config from %s: %s", CONFIG_PATH, e)
         return {}
+
+
+def save_config(config: Dict[str, Any]) -> None:
+    """Save the main configuration file."""
+    try:
+        os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+        with open(CONFIG_PATH, "w") as f:
+            json.dump(config, f, indent=2)
+        logger.info("Saved config to %s", CONFIG_PATH)
+    except IOError as e:
+        logger.error("Failed to save config to %s: %s", CONFIG_PATH, e)
 
 
 def load_theme_name_from_config() -> Optional[str]:


### PR DESCRIPTION
This commit introduces a new settings window to the news-tui client.

The settings window allows users to:
- Select which news sections to display in the main view.
- Create custom 'meta' sections that aggregate headlines from other sections.
- Save these preferences to the configuration file (`~/.config/news/config.json`).

This commit also includes the following improvements:
- The help screen now dynamically lists all available keybindings.
- The summary view provides a more informative message when no summary is available for a story.