### PR TITLE
feat: Add settings window and improve UI

### DIFF
--- a/src/news_tui/app.py
+++ b/src/news_tui/app.py
@@ -29,7 +29,7 @@ from .config import (
 from dataclasses import asdict
 from .datamodels import Section, Story
 from .sources.cbc import CBCSource
-from .screens import BookmarksScreen, HelpScreen, SettingsScreen, StoryViewScreen
+from .screens import BookmarksScreen, SettingsScreen, StoryViewScreen
 from .themes import THEMES
 from .widgets import SectionListItem, StatusBar
 
@@ -62,7 +62,7 @@ class NewsApp(App):
         Binding("r", "refresh", "Refresh"),
         Binding("b", "bookmark", "Bookmark"),
         Binding("B", "show_bookmarks", "Show Bookmarks"),
-        Binding("h", "show_help", "Help"),
+        Binding("h", "toggle_help", "Toggle Help"),
         Binding("s", "show_settings", "Settings"),
         Binding("left", "nav_left", "Navigate Left"),
         Binding("right", "nav_right", "Navigate Right"),
@@ -350,9 +350,6 @@ class NewsApp(App):
 
     def action_show_bookmarks(self) -> None:
         self.push_screen(BookmarksScreen())
-
-    def action_show_help(self) -> None:
-        self.push_screen(HelpScreen())
 
     def action_show_settings(self) -> None:
         """Show the settings screen."""

--- a/src/news_tui/screens.py
+++ b/src/news_tui/screens.py
@@ -155,23 +155,6 @@ class BookmarksScreen(Screen):
             table.add_row(b["title"], b["summary"] or "")
 
 
-class HelpScreen(Screen):
-    BINDINGS = [
-        Binding("escape,q,h,left", "app.pop_screen", "Back"),
-    ]
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield Footer()
-        yield Static("Keybindings", classes="pane-title")
-
-        bindings_text = ""
-        for b in self.app.BINDINGS:
-            bindings_text += f"{b.key}: {b.description}\n"
-
-        yield Static(bindings_text)
-
-
 class SettingsScreen(Screen):
     """Screen for app settings."""
 
@@ -202,7 +185,7 @@ class SettingsScreen(Screen):
     def on_mount(self) -> None:
         """Load sections and populate lists."""
         self.title = "Settings"
-        self.run_worker(self.load_sections, name="load_settings_sections")
+        self.run_worker(self.load_sections, name="load_settings_sections", thread=True)
 
     def load_sections(self) -> None:
         # This will run in a worker thread


### PR DESCRIPTION
This commit introduces a new settings window to the news-tui client.

The settings window allows users to:
- Select which news sections to display in the main view.
- Create custom 'meta' sections that aggregate headlines from other sections.
- Save these preferences to the configuration file (`~/.config/news/config.json`).

This commit also includes the following improvements:
- The help screen now uses Textual's built-in help, which is toggled with the 'h' key.
- The summary view provides a more informative message when no summary is available for a story.

fix: The application no longer crashes when opening the settings screen. This was caused by a `WorkerError` which has been resolved.