### PR TITLE
fix: Correct MarkdownViewer usage and persist theme

### DIFF
--- a/src/news_tui/app.py
+++ b/src/news_tui/app.py
@@ -23,6 +23,7 @@ from .config import (
     load_read_articles,
     load_bookmarks,
     save_bookmarks,
+    save_config,
     save_read_articles,
 )
 from dataclasses import asdict
@@ -326,6 +327,8 @@ class NewsApp(App):
 
     def action_switch_theme(self, theme: str) -> None:
         self.theme = theme
+        self.config["theme"] = theme
+        save_config(self.config)
 
     def action_toggle_left_pane(self) -> None:
         """Toggle the left pane."""

--- a/src/news_tui/screens.py
+++ b/src/news_tui/screens.py
@@ -19,6 +19,7 @@ from textual.widgets import (
     ListItem,
     ListView,
     LoadingIndicator,
+    MarkdownViewer,
     Static,
 )
 
@@ -26,21 +27,6 @@ from .config import load_bookmarks, save_config
 from .datamodels import Section, Story
 from .fetcher import Fetcher
 from .themes import THEMES
-
-# Markdown & scroll fallbacks for different Textual versions
-try:
-    from textual.widgets import MarkdownViewer as Markdown  # type: ignore
-except Exception:
-    try:
-        from textual.widgets import Markdown  # type: ignore
-    except Exception:
-        Markdown = Static  # type: ignore
-
-try:
-    from textual.containers import VerticalScroll  # some versions
-except Exception:
-    # fallback to Vertical for containing article content if VerticalScroll is missing
-    VerticalScroll = Vertical  # type: ignore
 
 
 # --- Story screen (separate) ---
@@ -63,7 +49,9 @@ class StoryViewScreen(Screen):
         # loading indicator and scrollable Markdown
         loading = LoadingIndicator(id="story-loading")
         yield loading
-        yield VerticalScroll(Markdown("", id="story-markdown"), id="story-scroll")
+        yield VerticalScroll(
+            MarkdownViewer(id="story-markdown"), id="story-scroll"
+        )
 
     def on_mount(self) -> None:
         self.title = self.story.title
@@ -106,31 +94,31 @@ class StoryViewScreen(Screen):
                 self.query_one("#story-scroll").display = True
             except Exception:
                 pass
-            md = self.query_one("#story-markdown")
+            md = self.query_one(MarkdownViewer)
             if isinstance(result, dict) and result.get("ok"):
-                md.update(result.get("content", ""))
+                md.document = result.get("content", "")
             else:
                 msg = (
                     result.get("content", "Unable to load article.")
                     if isinstance(result, dict)
                     else "Unable to load article."
                 )
-                md.update(f"[b {error_color}]{msg}[/]")
+                md.document = f"[b {error_color}]{msg}[/]"
         else:
             # worker not SUCCESS; if it's not running/pending treat as failure
             if event.state not in (WorkerState.PENDING, WorkerState.RUNNING):
                 try:
                     self.query_one("#story-loading", LoadingIndicator).display = False
                     self.query_one("#story-scroll").display = True
-                    md = self.query_one("#story-markdown")
-                    md.update(f"[b {error_color}]Unable to load article[/]")
+                    md = self.query_one(MarkdownViewer)
+                    md.document = f"[b {error_color}]Unable to load article[/]"
                 except Exception:
                     pass
 
     def action_open_in_browser(self) -> None:
         webbrowser.open(self.story.url)
 
-    def on_markdown_link_clicked(self, event: Markdown.LinkClicked) -> None:
+    def on_markdown_viewer_link_clicked(self, event: MarkdownViewer.LinkClicked) -> None:
         """Handle clicks on links in Markdown."""
         self.run_worker(lambda: webbrowser.open(event.href), thread=True)
 


### PR DESCRIPTION
- Fixed an `AttributeError` in `StoryViewScreen` by updating the code to use `md.document = ...` instead of `md.update(...)` for the `MarkdownViewer` widget. This aligns with the latest `textual` API.
- Implemented theme persistence by saving the selected theme to the configuration file whenever it's changed via the command palette. This ensures the user's theme choice is remembered across sessions.