### PR TITLE
fix: Address caching, theme, and config issues

### DIFF
--- a/src/news_tui/sources/cbc.py
+++ b/src/news_tui/sources/cbc.py
@@ -67,7 +67,7 @@ class CBCSource:
                 resp.raise_for_status()
                 logger.debug("Fetched %s OK", url)
                 content = resp.content
-                if self.cache:
+                if content and self.cache:
                     self.cache.set(url, base64.b64encode(content).decode("utf-8"))
                 return content
             except requests.RequestException as e:


### PR DESCRIPTION
- Fixed a bug where empty network responses were being cached, which caused articles to fail to load.
- Added a "Clear Cache" command to the command palette to allow users to manually clear the cache.
- Fixed a bug where the `Fetcher` could use a stale config after settings were changed by re-initializing it.
- Ensured that theme changes are correctly persisted to the configuration file.