### PR TITLE
fix: Robustly persist theme and fix article display

### DIFF
--- a/src/news_tui/app.py
+++ b/src/news_tui/app.py
@@ -341,8 +341,10 @@ class NewsApp(App):
 
     def action_switch_theme(self, theme: str) -> None:
         self.theme = theme
-        self.config["theme"] = theme
-        save_config(self.config)
+        config = load_config()
+        config["theme"] = theme
+        save_config(config)
+        self.config = config
 
     def action_toggle_left_pane(self) -> None:
         """Toggle the left pane."""

--- a/src/news_tui/screens.py
+++ b/src/news_tui/screens.py
@@ -95,15 +95,18 @@ class StoryViewScreen(Screen):
             except Exception:
                 pass
             md = self.query_one(MarkdownViewer)
-            if isinstance(result, dict) and result.get("ok"):
-                md.go(result.get("content", ""))
-            else:
-                msg = (
-                    result.get("content", "Unable to load article.")
-                    if isinstance(result, dict)
-                    else "Unable to load article."
-                )
-                md.go(f"[b {error_color}]{msg}[/]")
+            try:
+                if isinstance(result, dict) and result.get("ok"):
+                    md.go(result.get("content", ""))
+                else:
+                    msg = (
+                        result.get("content", "Unable to load article.")
+                        if isinstance(result, dict)
+                        else "Unable to load article."
+                    )
+                    md.go(f"[b {error_color}]{msg}[/]")
+            except Exception as e:
+                md.go(f"[b {error_color}]Error displaying article: {e}[/]")
         else:
             # worker not SUCCESS; if it's not running/pending treat as failure
             if event.state not in (WorkerState.PENDING, WorkerState.RUNNING):


### PR DESCRIPTION
- Implemented a more robust method for theme persistence by loading and saving the configuration file directly within the `action_switch_theme` method. This ensures that theme changes are always saved correctly.
- Added defensive error handling to the article display screen (`StoryViewScreen`) by wrapping the content rendering call in a `try-except` block. This will prevent the application from crashing if it encounters malformed article content and will display an error message instead.