### PR TITLE
Fix ImportError for THEMES

### DIFF
--- a/src/news_tui/main.py
+++ b/src/news_tui/main.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from .app import NewsApp
 from .config import enable_debug_log_to_tmp, load_config
-from .themes import THEMES
+from .theme_definitions import THEMES
 
 logger = logging.getLogger("news")
 


### PR DESCRIPTION
The application was failing to start due to an ImportError when importing the THEMES variable. This was because the import statement in `src/news_tui/main.py` was pointing to `news_tui.themes`, which does not exist.

The fix is to change the import to point to `news_tui.theme_definitions`, where the THEMES variable is defined.