### PR TITLE
Fix: Resolve outstanding UI bugs and cleanup

### DIFF
--- a/src/news_tui/screens.py
+++ b/src/news_tui/screens.py
@@ -178,10 +178,9 @@ class BookmarksScreen(Screen):
         self.title = "Bookmarks"
         table = self.query_one(DataTable)
         table.add_column("Title", width=50)
-        table.add_column("Summary")
         bookmarks = load_bookmarks()
         for b in bookmarks:
-            table.add_row(b["title"], b["summary"] or "")
+            table.add_row(b["title"])
 
 
 class SettingsScreen(Screen):

--- a/src/news_tui/widgets.py
+++ b/src/news_tui/widgets.py
@@ -40,25 +40,19 @@ class HeadlineItem(ListItem):
 
 
 class StatusBar(Static):
-    theme_name = reactive("default")
     loading_status = reactive("")
     keybinding_hint = reactive("")
 
     def on_mount(self) -> None:
-        self.set_interval(1, self.update_time)
-        self.theme_name = self.app.theme or "default"
-        self.watch(self.app, "theme", self._on_app_theme_changed)
-
-    def _on_app_theme_changed(self, theme: str) -> None:
-        self.theme_name = theme
+        self.update_display()
 
     def on_status_update(self, message: StatusUpdate) -> None:
         """Listen for status updates and update the hint."""
         self.keybinding_hint = message.text
 
-    def update_time(self) -> None:
-        time_str = datetime.now().strftime("%H:%M:%S")
-        status_items = [f"Theme: {self.theme_name}", time_str]
+    def update_display(self) -> None:
+        """Update the status bar display."""
+        status_items = []
         if self.loading_status:
             status_items.append(self.loading_status)
 
@@ -67,11 +61,8 @@ class StatusBar(Static):
 
         self.update(" | ".join(status_items))
 
-    def watch_theme_name(self, theme_name: str) -> None:
-        self.update_time()
-
     def watch_loading_status(self, loading_status: str) -> None:
-        self.update_time()
+        self.update_display()
 
     def watch_keybinding_hint(self, keybinding_hint: str) -> None:
-        self.update_time()
+        self.update_display()


### PR DESCRIPTION
This commit addresses the final set of UI bugs reported by the user.

- **Fix Status Bar:** The StatusBar widget has been refactored to remove the theme and clock display. It now only shows the loading status and a context-aware keybinding hint, which is updated via a message-passing system.

- **Fix Bookmarks Screen:** The Bookmarks screen has been fixed to remove the reference to the non-existent `summary` field, which was causing a crash.

- **Fix Story Page Scrolling:** The scrolling on the story page has been fixed by focusing the correct widget and removing the j/k keybindings as requested.

- **Hide Search Bar:** The headline search input is now hidden by default and only appears when activated.

- **Theme Enhancements:** Existing themes have been revised for better readability, and a new `cyberpunk` theme has been added.