### PR TITLE
feat: only log to file when --debug is passed

### DIFF
--- a/src/news_tui/config.py
+++ b/src/news_tui/config.py
@@ -36,27 +36,26 @@ UI_DEFAULTS = {
 }
 
 # --- Logging ---
-logging.basicConfig(
-    level=logging.INFO,
-    filename="newstui.log",
-    filemode="a",
-    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-)
 logger = logging.getLogger("news")
 
+def setup_logging(debug: bool = False) -> Optional[str]:
+    """Configure logging."""
+    if not debug:
+        logging.basicConfig(level=logging.CRITICAL, handlers=[logging.NullHandler()])
+        return None
 
-def enable_debug_log_to_tmp() -> str:
     ts = datetime.now().strftime("%Y%m%dT%H%M%S")
     pid = os.getpid()
     debug_path = f"/tmp/news_debug_{ts}_{pid}.log"
-    fh = logging.FileHandler(debug_path, mode="a")
-    fh.setLevel(logging.DEBUG)
-    fmt = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
-    fh.setFormatter(fmt)
-    logger.addHandler(fh)
-    logging.getLogger().addHandler(fh)
-    logger.setLevel(logging.DEBUG)
-    logging.getLogger().setLevel(logging.DEBUG)
+
+    # Use basicConfig to set up the root logger with a file handler
+    logging.basicConfig(
+        level=logging.DEBUG,
+        filename=debug_path,
+        filemode="a",
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    )
+
     logger.debug("Debug logging enabled to %s", debug_path)
     return debug_path
 

--- a/src/news_tui/main.py
+++ b/src/news_tui/main.py
@@ -9,7 +9,7 @@ import sys
 from typing import Optional
 
 from .app import NewsApp
-from .config import enable_debug_log_to_tmp, load_config, load_themes
+from .config import load_config, load_themes, setup_logging
 
 logger = logging.getLogger("news")
 
@@ -28,8 +28,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.debug:
-        debug_path = enable_debug_log_to_tmp()
+    debug_path = setup_logging(args.debug)
+    if debug_path:
         print(f"Debug logging enabled: {debug_path}", file=sys.stderr)
 
     config = load_config()


### PR DESCRIPTION
The application was previously creating a `newstui.log` file in the current working directory by default. This is undesirable behavior for a TUI application.

This change modifies the logging configuration to only create a log file when the user explicitly passes the `--debug` flag. When the `--debug` flag is not present, logging is disabled by using a `NullHandler`.

The debug log file is now created in the `/tmp` directory with a unique timestamp and process ID to avoid name collisions.