### PR TITLE
Fix: Replace Footer with StatusBar and correct UI in StoryViewScreen

### DIFF
--- a/src/news_tui/app.py
+++ b/src/news_tui/app.py
@@ -98,7 +98,7 @@ class NewsApp(App):
     def get_keybinding_style(self) -> str:
         """Return the appropriate keybinding style for the current theme."""
         if self.theme_name.startswith("cbc-"):
-            return "#ff5555"
+            return "white"
         return "$accent"
 
     def apply_theme_styles(self, screen) -> None:

--- a/src/news_tui/screens.py
+++ b/src/news_tui/screens.py
@@ -65,7 +65,6 @@ class StoryViewScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield Header()
-        yield StatusBar()
         # loading indicator and scrollable Markdown
         loading = LoadingIndicator(id="story-loading")
         yield loading
@@ -73,6 +72,7 @@ class StoryViewScreen(Screen):
             MarkdownWidget("", id="story-markdown"),
             id="story-scroll",
         )
+        yield StatusBar()
 
     def on_mount(self) -> None:
         self.title = self.story.title


### PR DESCRIPTION
This commit addresses several issues in the StoryViewScreen:

1.  Resolves an `AttributeError` crash by replacing the default Textual `Footer` with the custom `StatusBar` widget, which has the required `set_keybindings` method.
2.  Fixes the position of the `StatusBar` by moving it to the end of the `compose` method, ensuring it renders at the bottom of the screen.
3.  Corrects the keybinding text color for `cbc-` themes to be white, providing proper contrast against the red background.

These changes fix the initial crash and address the user's feedback on the UI, resulting in a correctly functioning and styled StoryViewScreen.